### PR TITLE
Fix typo in legacy service configuration

### DIFF
--- a/src/Resources/config/csv.legacy.xml
+++ b/src/Resources/config/csv.legacy.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="ajgl_csv" class="Ajgl\Csv\Csv" factory-class="Ajgl\Csv\Csv" factory-method="crate"/>
+        <service id="ajgl_csv" class="Ajgl\Csv\Csv" factory-class="Ajgl\Csv\Csv" factory-method="create"/>
     </services>
 
 </container>


### PR DESCRIPTION
The csv.legacy.xml file has a typo in it which prevents using the ajgl_csv service in at least Symfony 2.8. This fixes it.
