### PR TITLE
Add support for Symfony v.2.8 and v.3.4, PHP v.7.1 and v.7.2, drop support for PHP v.5.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
     - php: 5.4
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
+    - php: 5.4
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.5
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.4
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.4
     - php: 5.5
     - php: 5.6
     - php: 7
+    - php: 7.1
+    - php: 7.2
     - php: hhvm
 
 before_script:
@@ -17,4 +18,3 @@ script: phpunit --coverage-clover=coverage.clover
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5.9",
         "ajgl/csv": "^0.4",
-        "symfony/framework-bundle": "^2.3"
+        "symfony/framework-bundle": "^2.3|^2.8|^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.4",
         "ajgl/csv": "^0.4",
         "symfony/framework-bundle": "^2.3|^2.8|^3.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4",
         "ajgl/csv": "^0.4",
-        "symfony/framework-bundle": "^2.3|^2.8|^3.4"
+        "symfony/framework-bundle": "^2.7|^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0"


### PR DESCRIPTION
Dropping support for PHP v.5.4 is necessary since Symfony v.3.4 requires PHP version >= 5.5.9.

This has not been thoroughly tested.